### PR TITLE
Integrate Netlify for Open Source projects

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,11 @@
+# Contributor Code of Conduct
+
+As contributors and maintainers of the astronomy-engine project, we pledge to respect everyone who contributes by posting issues, updating documentation, submitting pull requests, providing feedback in comments, and any other activities.
+
+Communication through any channel must be constructive and never resort to personal attacks, trolling, public or private harassment, insults, or other unprofessional conduct.
+
+We promise to extend courtesy and respect to everyone involved in this project regardless of gender, gender identity, sexual orientation, disability, age, race, ethnicity, religion, or level of experience. We expect anyone contributing to the project to do the same.
+
+If any member of the community violates this code of conduct, the maintainers of the project may take action, removing issues, comments, and PRs or blocking accounts as deemed appropriate.
+
+If you are subject to or witness unacceptable behavior, or have any other concerns, please contact @cosinekitty.

--- a/README.md
+++ b/README.md
@@ -1,4 +1,8 @@
-# Astronomy Engine <span style="vertical-align: middle;">[![Build Status](https://travis-ci.com/cosinekitty/astronomy.svg)](https://travis-ci.com/cosinekitty/astronomy)</span> <span style="vertical-align: middle;">[![npm package](https://img.shields.io/npm/v/astronomy-engine.svg)](https://www.npmjs.com/package/astronomy-engine)</span>
+# Astronomy Engine
+
+[![Build Status](https://travis-ci.com/cosinekitty/astronomy.svg)](https://travis-ci.com/cosinekitty/astronomy)
+[![npm package](https://img.shields.io/npm/v/astronomy-engine.svg)](https://www.npmjs.com/package/astronomy-engine)
+[![Netlify Status](https://api.netlify.com/api/v1/badges/fb766ed0-27e1-4c4e-82bf-a0fd455113a6/deploy-status)](https://app.netlify.com/sites/astronomy-engine/deploys)
 
 ### Supported Programming Languages
 
@@ -96,9 +100,9 @@ Calculations are also verified to be identical among all the supported programmi
 - Predicts dates of maximum elongation for Mercury and Venus.
 
 - Converts angular and vector coordinates among the following orientations:
-    - Equatorial J2000
-    - Equatorial equator-of-date
-    - Ecliptic J2000
-    - Topocentric Horizontal
+  - Equatorial J2000
+  - Equatorial equator-of-date
+  - Ecliptic J2000
+  - Topocentric Horizontal
 
 - Determines which constellation contains a given point in the sky.


### PR DESCRIPTION
To [apply for an Open Source Account](https://opensource-form.netlify.com/) in Netlify we need a Code of Conduct and the Netlify badge in the main page.

I'm not sure if we need to deploy an initial website with the badge in the footer (I was able to deploy an Angular App in GitHub Pages here: https://matheo.github.io/ui-test/) so I might try to build and deploy the App in GitHub pages first, and then we see if we really need Netlify, perhaps it seems like a better platform to support the website via Continuous Deployment.

Question: How do you publish the library to `npm`?
it's been done manyally after merging to `master`?
or can it be done before pushing to git? (so we can use it in Netlify)