### PR TITLE
Make the generated time of demos compatible with Safari

### DIFF
--- a/demo/browser/moonphase.html
+++ b/demo/browser/moonphase.html
@@ -128,7 +128,7 @@
                 var hour = Pad(date.getHours(), 2);
                 var minute = Pad(date.getMinutes(), 2);
                 var second = Pad(date.getSeconds(), 2);
-                return `${year}-${month}-${day} ${hour}:${minute}:${second}`;
+                return `${year}-${month}-${day}T${hour}:${minute}:${second}`;
             }
 
             function UpdateScreen() {

--- a/demo/browser/moonradar.html
+++ b/demo/browser/moonradar.html
@@ -143,7 +143,7 @@
                 var hour = Pad(date.getHours(), 2);
                 var minute = Pad(date.getMinutes(), 2);
                 var second = Pad(date.getSeconds(), 2);
-                return `${year}-${month}-${day} ${hour}:${minute}:${second}`;
+                return `${year}-${month}-${day}T${hour}:${minute}:${second}`;
             }
 
             function FormatCoord(x) {

--- a/demo/browser/positions.html
+++ b/demo/browser/positions.html
@@ -201,7 +201,7 @@
                 var hour = Pad(date.getHours(), 2);
                 var minute = Pad(date.getMinutes(), 2);
                 var second = Pad(date.getSeconds(), 2);
-                return `${year}-${month}-${day} ${hour}:${minute}:${second}`;
+                return `${year}-${month}-${day}T${hour}:${minute}:${second}`;
             }
 
             function FormatCoord(x) {

--- a/demo/browser/riseset.html
+++ b/demo/browser/riseset.html
@@ -115,7 +115,7 @@
                 var hour = Pad(date.getHours(), 2);
                 var minute = Pad(date.getMinutes(), 2);
                 var second = Pad(date.getSeconds(), 2);
-                return `${year}-${month}-${day} ${hour}:${minute}:${second}`;
+                return `${year}-${month}-${day}T${hour}:${minute}:${second}`;
             }
 
             function DisplayEvent(name, evt) {


### PR DESCRIPTION
It won't show the calculated table result in Safari

The fix is per https://stackoverflow.com/a/45152231

You should be able to reproduce the issue with Epiphany in Linux also