### PR TITLE
jvm: Make the demo project able to produce fat jars

### DIFF
--- a/demo/android/app/build.gradle.kts
+++ b/demo/android/app/build.gradle.kts
@@ -55,6 +55,7 @@ dependencies {
     implementation("androidx.lifecycle:lifecycle-runtime-ktx:2.4.1")
     implementation("androidx.activity:activity-compose:1.4.0")
     testImplementation("junit:junit:4.13.2")
+    testImplementation(kotlin("test"))
     androidTestImplementation("androidx.test.ext:junit:1.1.3")
     androidTestImplementation("androidx.test.espresso:espresso-core:3.4.0")
     androidTestImplementation("androidx.compose.ui:ui-test-junit4:$composeVersion")

--- a/demo/android/app/src/test/kotlin/io/github/cosinekitty/astronomy/ExampleUnitTest.kt
+++ b/demo/android/app/src/test/kotlin/io/github/cosinekitty/astronomy/ExampleUnitTest.kt
@@ -1,8 +1,7 @@
 package io.github.cosinekitty.astronomy
 
 import org.junit.Test
-
-import org.junit.Assert.*
+import kotlin.test.assertEquals
 
 /**
  * Example local unit test, which will execute on the development machine (host).

--- a/demo/java/build.gradle.kts
+++ b/demo/java/build.gradle.kts
@@ -21,6 +21,12 @@ application {
     mainClass.set("io.github.cosinekitty.astronomy.demo.Main")
 }
 
+tasks.jar {
+    manifest.attributes["Main-Class"] = "io.github.cosinekitty.astronomy.demo.Main"
+    from(configurations.runtimeClasspath.get().map(::zipTree))
+    duplicatesStrategy = DuplicatesStrategy.EXCLUDE
+}
+
 tasks.getByName<Test>("test") {
     useJUnitPlatform()
 }

--- a/source/kotlin/build.gradle.kts
+++ b/source/kotlin/build.gradle.kts
@@ -18,6 +18,7 @@ dependencies {
     testImplementation("org.junit.jupiter:junit-jupiter-api:$junit5Version")
     testImplementation("org.junit.jupiter:junit-jupiter-params:$junit5Version")
     testRuntimeOnly("org.junit.jupiter:junit-jupiter-engine:$junit5Version")
+    testImplementation(kotlin("test"))
 }
 
 tasks.test {

--- a/source/kotlin/src/test/kotlin/io/github/cosinekitty/astronomy/Tests.kt
+++ b/source/kotlin/src/test/kotlin/io/github/cosinekitty/astronomy/Tests.kt
@@ -1,9 +1,9 @@
 package io.github.cosinekitty.astronomy
 
-import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.CsvSource
+import kotlin.test.assertEquals
 
 class Tests {
     @Test


### PR DESCRIPTION
Adopted from https://stackoverflow.com/a/63332420

So one can run the demo with `./gradlew jar && java -jar build/libs/astronomy-demo-0.0.1.jar`
instead `./gradlew run`