### PR TITLE
kotlin: Don't run test on jitpack server

### DIFF
--- a/jitpack.yml
+++ b/jitpack.yml
@@ -1,2 +1,2 @@
 install:
-  - cd source/kotlin && ./gradlew build publishToMavenLocal
+  - cd source/kotlin && ./gradlew build publishToMavenLocal --exclude-task test


### PR DESCRIPTION
Tests needs more bootstrap to work properly and we are doing so in
our CI anyway so let's just exclude test task in jitpack servers.

As the result of the discussion in https://github.com/cosinekitty/astronomy/issues/185

Fixes https://github.com/cosinekitty/astronomy/issues/185