### PR TITLE
kotlin: Include sources artifact in the release

### DIFF
--- a/source/kotlin/build.gradle.kts
+++ b/source/kotlin/build.gradle.kts
@@ -29,10 +29,17 @@ configure<JavaPluginExtension> {
     sourceCompatibility = JavaVersion.VERSION_1_8
 }
 
+val sourceJar by tasks.creating(Jar::class) {
+    dependsOn(tasks["classes"])
+    archiveClassifier.set("sources")
+    from(sourceSets["main"].allSource)
+}
+
 publishing {
     publications {
         register("mavenJava", MavenPublication::class) {
-            from(components["java"])
+            from(components["kotlin"])
+            artifact(sourceJar)
         }
     }
 }


### PR DESCRIPTION
This is done for more convenience to access documentation and source while using the library which makes the following possible in the IDE:

<img width="448" alt="image" src="https://user-images.githubusercontent.com/833473/162438685-b9346a2e-5abe-41eb-9504-a5854e3035e3.png">

which uses the same approach as https://github.com/CafeteriaGuild/CoffeeComputersCore/blob/ef8316c39af4e13fe848ab3a6951565e6bab7a0f/build.gradle.kts#L47
