### PR TITLE
kotlin: Remove Kt suffix from file top level object

### DIFF
--- a/generate/template/astronomy.kt
+++ b/generate/template/astronomy.kt
@@ -1,5 +1,3 @@
-package io.github.cosinekitty.astronomy
-
 /*
     Astronomy Engine for Kotlin / JVM.
     https://github.com/cosinekitty/astronomy
@@ -26,6 +24,9 @@ package io.github.cosinekitty.astronomy
     OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
     SOFTWARE.
 */
+@file:JvmName("Astronomy")
+
+package io.github.cosinekitty.astronomy
 
 import java.text.SimpleDateFormat
 import java.util.*

--- a/source/kotlin/src/main/kotlin/io/github/cosinekitty/astronomy/astronomy.kt
+++ b/source/kotlin/src/main/kotlin/io/github/cosinekitty/astronomy/astronomy.kt
@@ -1,5 +1,3 @@
-package io.github.cosinekitty.astronomy
-
 /*
     Astronomy Engine for Kotlin / JVM.
     https://github.com/cosinekitty/astronomy
@@ -26,6 +24,9 @@ package io.github.cosinekitty.astronomy
     OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
     SOFTWARE.
 */
+@file:JvmName("Astronomy")
+
+package io.github.cosinekitty.astronomy
 
 import java.text.SimpleDateFormat
 import java.util.*


### PR DESCRIPTION
Otherwise in Java top level functions will be seen as `astronomyKt.seasons` for example.