### PR TITLE
kotlin: Directly provide the library to demo

### DIFF
--- a/demo/java/build.gradle.kts
+++ b/demo/java/build.gradle.kts
@@ -8,11 +8,13 @@ version = "0.0.1"
 
 repositories {
     mavenCentral()
-    maven("https://jitpack.io")
+    // maven("https://jitpack.io")
 }
 
 dependencies {
-    implementation("com.github.ebraminio:astronomy:2bcbf09edd335a42e013135e04c1418d0bdcde32")
+    implementation(fileTree("../../source/kotlin/build/libs"))
+    // Or resolve it from jitpack like,
+    //   implementation("com.github.cosinekitty:astronomy:0.0.1")
     testImplementation("org.junit.jupiter:junit-jupiter-api:5.8.2")
     testRuntimeOnly("org.junit.jupiter:junit-jupiter-engine")
 }

--- a/demo/java/demotest
+++ b/demo/java/demotest
@@ -10,6 +10,9 @@ RunDemo()
     java -jar build/libs/astronomy-demo-0.0.1.jar $*
 }
 
+(echo "Build astronomy library jar" && cd ../../source/kotlin && ./gradlew fatJar)
+
+echo "Build astronomy java demo"
 ./gradlew jar || Fail "Cannot build jar file."
 echo ""
 echo "Java demos: starting"

--- a/source/kotlin/build.gradle.kts
+++ b/source/kotlin/build.gradle.kts
@@ -35,6 +35,12 @@ val sourceJar by tasks.creating(Jar::class) {
     from(sourceSets["main"].allSource)
 }
 
+task("fatJar", type = Jar::class) {
+    from(configurations.runtimeClasspath.get().map(::zipTree))
+    duplicatesStrategy = DuplicatesStrategy.EXCLUDE
+    with(tasks.jar.get())
+}
+
 publishing {
     publications {
         register("mavenJava", MavenPublication::class) {


### PR DESCRIPTION
No longer having jitpack as the middle man and just directly building
demo from the project itself.

Alternative to #197