### PR TITLE
kotlin: Upgrade Android example to use the new namings

### DIFF
--- a/demo/android/app/build.gradle.kts
+++ b/demo/android/app/build.gradle.kts
@@ -46,7 +46,9 @@ android {
 }
 
 dependencies {
-    implementation("com.github.cosinekitty:astronomy:8fd8d7b62465d6de91a9fe39de6d1d711904fd4b")
+    implementation(fileTree("../../../source/kotlin/build/libs"))
+    // In an independent project resolve it from jitpack like,
+    //   implementation("com.github.cosinekitty:astronomy:x.y.z")
     implementation("androidx.core:core-ktx:1.7.0")
     implementation("androidx.compose.ui:ui:$composeVersion")
     implementation("androidx.compose.material:material:$composeVersion")

--- a/demo/android/app/src/main/kotlin/io/github/cosinekitty/astronomy/MainActivity.kt
+++ b/demo/android/app/src/main/kotlin/io/github/cosinekitty/astronomy/MainActivity.kt
@@ -32,7 +32,7 @@ fun MainScreen() {
 
 @Composable
 fun Content() {
-    Text(text = AstroTime(Date()).toString())
+    Text(text = Time(Date()).toString())
 }
 
 @Composable

--- a/demo/android/settings.gradle.kts
+++ b/demo/android/settings.gradle.kts
@@ -10,7 +10,7 @@ dependencyResolutionManagement {
     repositories {
         google()
         mavenCentral()
-        maven("https://jitpack.io")
+        // maven("https://jitpack.io")
     }
 }
 rootProject.name = "Astronomy"

--- a/demo/java/build.gradle.kts
+++ b/demo/java/build.gradle.kts
@@ -13,8 +13,9 @@ repositories {
 
 dependencies {
     implementation(fileTree("../../source/kotlin/build/libs"))
-    // Or resolve it from jitpack like,
-    //   implementation("com.github.cosinekitty:astronomy:0.0.1")
+    implementation("org.jetbrains.kotlin:kotlin-stdlib:1.6.20") // Not needed if resolved from jitpack
+    // In an independent project resolve it from jitpack like,
+    //   implementation("com.github.cosinekitty:astronomy:x.y.z")
     testImplementation("org.junit.jupiter:junit-jupiter-api:5.8.2")
     testRuntimeOnly("org.junit.jupiter:junit-jupiter-engine")
 }

--- a/demo/java/demotest
+++ b/demo/java/demotest
@@ -10,7 +10,6 @@ RunDemo()
     java -jar build/libs/astronomy-demo-0.0.1.jar $*
 }
 
-echo "Build astronomy java demo"
 ./gradlew jar || Fail "Cannot build jar file."
 echo ""
 echo "Java demos: starting"

--- a/generate/kotlindoc/kotlin_prefix.md
+++ b/generate/kotlindoc/kotlin_prefix.md
@@ -19,7 +19,7 @@ allprojects {
 Now add the dependency:
 ```kotlin
 dependencies {
-    implementation("io.github.cosinekitty:astronomy:0.0.1")
+    implementation("io.github.cosinekitty:astronomy:x.y.z")
 }
 ```
 

--- a/generate/run.bat
+++ b/generate/run.bat
@@ -234,7 +234,7 @@ if exist build (
         exit /b 1
     )
 )
-call gradlew.bat assemble build test dokkaGfm fatJar
+call gradlew.bat assemble build test dokkaGfm jar
 if errorlevel 1 (exit /b 1)
 popd
 

--- a/generate/unit_test_kotlin
+++ b/generate/unit_test_kotlin
@@ -12,7 +12,7 @@ rm -f temp/k_check.txt
 
 cd ../source/kotlin || Fail "Cannot change dir to ../source/kotlin"
 rm -rf build
-if ! ./gradlew assemble build test dokkaGfm fatJar; then
+if ! ./gradlew assemble build test dokkaGfm jar; then
     # Dump the contents of the unit tests to the console,
     # so if the test fails on GitHub Actions, I can see what went wrong.
     cat build/test-results/test/*.xml

--- a/source/kotlin/README.md
+++ b/source/kotlin/README.md
@@ -19,7 +19,7 @@ allprojects {
 Now add the dependency:
 ```kotlin
 dependencies {
-    implementation("io.github.cosinekitty:astronomy:0.0.1")
+    implementation("io.github.cosinekitty:astronomy:x.y.z")
 }
 ```
 


### PR DESCRIPTION
It turned it is little more tricky than it should be, as Android itself brings its own JDK, fatJar which will contain Kotlin's runtime are not usable in Android and this change considers that.