### PR TITLE
kotlin: Improve access of companions object fields/methods in Java

### DIFF
--- a/generate/template/astronomy.kt
+++ b/generate/template/astronomy.kt
@@ -473,6 +473,7 @@ class Time private constructor(
     internal fun julianMillennia() = tt / DAYS_PER_MILLENNIUM
 
     companion object {
+        @JvmStatic
         private val origin = GregorianCalendar(TimeZoneUtc).also {
             it.set(2000, 0, 1, 12, 0, 0)
             it.set(Calendar.MILLISECOND, 0)
@@ -480,6 +481,7 @@ class Time private constructor(
 
         private const val MILLIS_PER_DAY = 24 * 3600 * 1000
 
+        @JvmStatic
         private val dateFormat = SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSS'Z'").also {
             it.timeZone = TimeZoneUtc
         }
@@ -498,6 +500,7 @@ class Time private constructor(
          *
          * @param tt The number of days after the J2000 epoch.
          */
+        @JvmStatic
         fun fromTerrestrialTime(tt: Double): Time = Time(universalTime(tt), tt)
     }
 }
@@ -547,6 +550,7 @@ internal data class TerseVector(var x: Double, var y: Double, var z: Double) {
     }
 
     companion object {
+        @JvmStatic
         fun zero() = TerseVector(0.0, 0.0, 0.0)
     }
 }
@@ -1004,7 +1008,8 @@ class RotationMatrix(
          * This matrix can be the starting point for other operations,
          * such as calling a series of [RotationMatrix.combine] or [RotationMatrix.pivot].
          */
-        fun identity() = RotationMatrix (
+        @JvmStatic
+        fun identity() = RotationMatrix(
             1.0, 0.0, 0.0,
             0.0, 1.0, 0.0,
             0.0, 0.0, 1.0
@@ -1989,7 +1994,7 @@ internal fun peakMoonShadow(searchCenterTime: Time): ShadowInfo {
     val window = 0.03       // days before/after new moon to search for minimum shadow distance
     val t1 = searchCenterTime.addDays(-window)
     val t2 = searchCenterTime.addDays(+window)
-    val tx = search(moonShadowSlopeContext, t1, t2, 1.0) ?:
+    val tx = search(t1, t2, 1.0, moonShadowSlopeContext) ?:
         throw InternalError("Failed to find Moon peak shadow event.")
     return moonShadow(tx)
 }

--- a/source/kotlin/doc/-rotation-matrix/-companion/identity.md
+++ b/source/kotlin/doc/-rotation-matrix/-companion/identity.md
@@ -3,6 +3,9 @@
 # identity
 
 [jvm]\
+
+@[JvmStatic](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin.jvm/-jvm-static/index.html)
+
 fun [identity](identity.md)(): [RotationMatrix](../index.md)
 
 Creates an identity rotation matrix.

--- a/source/kotlin/doc/-rotation-matrix/-companion/index.md
+++ b/source/kotlin/doc/-rotation-matrix/-companion/index.md
@@ -9,4 +9,4 @@ object [Companion](index.md)
 
 | Name | Summary |
 |---|---|
-| [identity](identity.md) | [jvm]<br>fun [identity](identity.md)(): [RotationMatrix](../index.md)<br>Creates an identity rotation matrix. |
+| [identity](identity.md) | [jvm]<br>@[JvmStatic](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin.jvm/-jvm-static/index.html)<br>fun [identity](identity.md)(): [RotationMatrix](../index.md)<br>Creates an identity rotation matrix. |

--- a/source/kotlin/doc/-time/-companion/from-terrestrial-time.md
+++ b/source/kotlin/doc/-time/-companion/from-terrestrial-time.md
@@ -3,6 +3,9 @@
 # fromTerrestrialTime
 
 [jvm]\
+
+@[JvmStatic](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin.jvm/-jvm-static/index.html)
+
 fun [fromTerrestrialTime](from-terrestrial-time.md)(tt: [Double](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-double/index.html)): [Time](../index.md)
 
 Creates a Time object from a Terrestrial Time day value.

--- a/source/kotlin/doc/-time/-companion/index.md
+++ b/source/kotlin/doc/-time/-companion/index.md
@@ -9,4 +9,4 @@ object [Companion](index.md)
 
 | Name | Summary |
 |---|---|
-| [fromTerrestrialTime](from-terrestrial-time.md) | [jvm]<br>fun [fromTerrestrialTime](from-terrestrial-time.md)(tt: [Double](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-double/index.html)): [Time](../index.md)<br>Creates a Time object from a Terrestrial Time day value. |
+| [fromTerrestrialTime](from-terrestrial-time.md) | [jvm]<br>@[JvmStatic](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin.jvm/-jvm-static/index.html)<br>fun [fromTerrestrialTime](from-terrestrial-time.md)(tt: [Double](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-double/index.html)): [Time](../index.md)<br>Creates a Time object from a Terrestrial Time day value. |

--- a/source/kotlin/src/main/kotlin/io/github/cosinekitty/astronomy/astronomy.kt
+++ b/source/kotlin/src/main/kotlin/io/github/cosinekitty/astronomy/astronomy.kt
@@ -473,6 +473,7 @@ class Time private constructor(
     internal fun julianMillennia() = tt / DAYS_PER_MILLENNIUM
 
     companion object {
+        @JvmStatic
         private val origin = GregorianCalendar(TimeZoneUtc).also {
             it.set(2000, 0, 1, 12, 0, 0)
             it.set(Calendar.MILLISECOND, 0)
@@ -480,6 +481,7 @@ class Time private constructor(
 
         private const val MILLIS_PER_DAY = 24 * 3600 * 1000
 
+        @JvmStatic
         private val dateFormat = SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSS'Z'").also {
             it.timeZone = TimeZoneUtc
         }
@@ -498,6 +500,7 @@ class Time private constructor(
          *
          * @param tt The number of days after the J2000 epoch.
          */
+        @JvmStatic
         fun fromTerrestrialTime(tt: Double): Time = Time(universalTime(tt), tt)
     }
 }
@@ -547,6 +550,7 @@ internal data class TerseVector(var x: Double, var y: Double, var z: Double) {
     }
 
     companion object {
+        @JvmStatic
         fun zero() = TerseVector(0.0, 0.0, 0.0)
     }
 }
@@ -1004,7 +1008,8 @@ class RotationMatrix(
          * This matrix can be the starting point for other operations,
          * such as calling a series of [RotationMatrix.combine] or [RotationMatrix.pivot].
          */
-        fun identity() = RotationMatrix (
+        @JvmStatic
+        fun identity() = RotationMatrix(
             1.0, 0.0, 0.0,
             0.0, 1.0, 0.0,
             0.0, 0.0, 1.0
@@ -1989,7 +1994,7 @@ internal fun peakMoonShadow(searchCenterTime: Time): ShadowInfo {
     val window = 0.03       // days before/after new moon to search for minimum shadow distance
     val t1 = searchCenterTime.addDays(-window)
     val t2 = searchCenterTime.addDays(+window)
-    val tx = search(moonShadowSlopeContext, t1, t2, 1.0) ?:
+    val tx = search(t1, t2, 1.0, moonShadowSlopeContext) ?:
         throw InternalError("Failed to find Moon peak shadow event.")
     return moonShadow(tx)
 }


### PR DESCRIPTION
Background: For some reason Kotlin doesn't have static fields and methods in language level like the way exists in Java / C# and instead got companion objects to act like them.

In order to make those companion objects more accessible in Java level, there is `@JvmStatic` annotation which marking all the things with it which is a common pattern,

See the following issue which we actually have also about useless warnings Dokka gives about companion object documentation, https://github.com/Kotlin/dokka/issues/200 

> Companion objects that consist of no fields and all `@JvmStatic` methods are effectively redundant, especially for Java users who will want to use static methods as normal. 

Aside from the problem which we also have, this is actually just doing such thing here for better accessibility in Java.