### PR TITLE
js: Revive moon radar demo

### DIFF
--- a/demo/browser/moonradar.html
+++ b/demo/browser/moonradar.html
@@ -85,7 +85,7 @@
             var Options;
 
             function ParseDate(s) {
-                return new Date(s.replace(' ', 'T'));   // Safari doesn't like the space character
+                return new Date((s || '').replace(' ', 'T'));   // Safari doesn't like the space character
             }
 
             function IsValidNumber(s) {


### PR DESCRIPTION
Apparently caller could send undefined as a value, this just makes it
regardless.

I think however we can look at why callers have sent undefined or when it got break, this is just one possible fix and sure you can suggest better one.