### PR TITLE
kotlin: Revert two of my changes for efficiency consideration

### DIFF
--- a/generate/template/astronomy.kt
+++ b/generate/template/astronomy.kt
@@ -5144,7 +5144,14 @@ fun nextTransit(body: Body, prevTransitTime: Time) =
  * of how Jupiter and its moons look from Earth.
  */
 fun jupiterMoons(time: Time) =
-    JupiterMoonsInfo(jupiterMoonModel.map { calcJupiterMoon(time, it) }.toTypedArray())
+    JupiterMoonsInfo(
+        arrayOf(
+            calcJupiterMoon(time, jupiterMoonModel[0]),
+            calcJupiterMoon(time, jupiterMoonModel[1]),
+            calcJupiterMoon(time, jupiterMoonModel[2]),
+            calcJupiterMoon(time, jupiterMoonModel[3])
+        )
+    )
 
 /**
  * Searches for a time at which a function's value increases through zero.

--- a/source/kotlin/src/main/kotlin/io/github/cosinekitty/astronomy/astronomy.kt
+++ b/source/kotlin/src/main/kotlin/io/github/cosinekitty/astronomy/astronomy.kt
@@ -5144,7 +5144,14 @@ fun nextTransit(body: Body, prevTransitTime: Time) =
  * of how Jupiter and its moons look from Earth.
  */
 fun jupiterMoons(time: Time) =
-    JupiterMoonsInfo(jupiterMoonModel.map { calcJupiterMoon(time, it) }.toTypedArray())
+    JupiterMoonsInfo(
+        arrayOf(
+            calcJupiterMoon(time, jupiterMoonModel[0]),
+            calcJupiterMoon(time, jupiterMoonModel[1]),
+            calcJupiterMoon(time, jupiterMoonModel[2]),
+            calcJupiterMoon(time, jupiterMoonModel[3])
+        )
+    )
 
 /**
  * Searches for a time at which a function's value increases through zero.


### PR DESCRIPTION
This partially reverts two of my changes for efficiency considerations. Comparing to the original code, the space indention of `arrayOf` is now a bit more idiomatic and `HashMap` is turned to `hashMapOf()` which matches what it was here initially.

```
/**
 * Returns an empty new [HashMap].
 *
 * @sample samples.collections.Maps.Instantiation.emptyHashMap
 */
@SinceKotlin("1.1")
@kotlin.internal.InlineOnly
public inline fun <K, V> hashMapOf(): HashMap<K, V> = HashMap<K, V>()
```