### PR TITLE
Kotlin: Use Instant.parse instead a custom date parser

### DIFF
--- a/demo/java/src/main/java/io/github/cosinekitty/astronomy/demo/Main.java
+++ b/demo/java/src/main/java/io/github/cosinekitty/astronomy/demo/Main.java
@@ -1,8 +1,9 @@
 package io.github.cosinekitty.astronomy.demo;
 
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
+import java.time.Instant;
+import java.time.format.DateTimeParseException;
 import java.util.Date;
+
 import io.github.cosinekitty.astronomy.*;
 
 public class Main {
@@ -25,27 +26,14 @@ public class Main {
             Date now = new Date();
             return Time.fromMillisecondsSince1970(now.getTime());
         }
-        Pattern pattern = Pattern.compile("^(\\d{4})-(\\d{2})-(\\d{2})(T(\\d{2}):(\\d{2})(:(\\d{2}(\\.\\d+)?))?Z)$");
-        Matcher matcher = pattern.matcher(args[index]);
-        if (matcher.find()) {
-            int year = Integer.parseInt(matcher.group(1));
-            int month = Integer.parseInt(matcher.group(2));
-            int day = Integer.parseInt(matcher.group(3));
-            int hour = 0;
-            int minute = 0;
-            double second = 0.0;
-            if (!matcher.group(4).isEmpty()) {
-                hour = Integer.parseInt(matcher.group(5));
-                minute = Integer.parseInt(matcher.group(6));
-                if (!matcher.group(7).isEmpty()) {
-                    second = Double.parseDouble((matcher.group(8)));
-                }
-            }
-            return new Time(year, month, day, hour, minute, second);
+        try {
+            Instant instant = Instant.parse(args[index]);
+            return Time.fromMillisecondsSince1970(instant.toEpochMilli());
+        } catch (DateTimeParseException e) {
+            System.out.print("FATAL: Invalid date/time syntax: ");
+            System.out.println(args[index]);
+            return null;
         }
-        System.out.print("FATAL: Invalid date/time syntax: ");
-        System.out.println(args[index]);
-        return null;
     }
 
     public static void main(String[] args) {
@@ -66,8 +54,7 @@ public class Main {
                     break;
 
                 case "now":
-                    Date now = new Date();
-                    Time time = Time.fromMillisecondsSince1970(now.getTime());
+                    Time time = Time.fromMillisecondsSince1970(System.currentTimeMillis());
                     System.out.println(time);
                     rc = 0;
                     break;

--- a/demo/java/src/main/java/io/github/cosinekitty/astronomy/demo/MoonPhase.java
+++ b/demo/java/src/main/java/io/github/cosinekitty/astronomy/demo/MoonPhase.java
@@ -32,7 +32,7 @@ public class MoonPhase {
     }
 
     private static String quarterName(int quarter) {
-        switch(quarter) {
+        switch (quarter) {
             case 0: return "New Moon";
             case 1: return "First Quarter";
             case 2: return "Full Moon";

--- a/demo/java/src/test/java/io/github/cosinekitty/astronomy/demo/MainTests.java
+++ b/demo/java/src/test/java/io/github/cosinekitty/astronomy/demo/MainTests.java
@@ -4,7 +4,6 @@ import io.github.cosinekitty.astronomy.Time;
 import org.junit.jupiter.api.Test;
 
 import java.time.Instant;
-import java.util.Date;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
@@ -12,6 +11,6 @@ public class MainTests {
     @Test
     void main() {
         String time = "2022-01-01T12:00:00.000Z";
-        assertEquals(time, new Time(Date.from(Instant.parse(time))).toString());
+        assertEquals(time, Time.fromMillisecondsSince1970(Instant.parse(time).toEpochMilli()).toString());
     }
 }


### PR DESCRIPTION
Also fixes the test which had the same code.

I think also `toEpochMilli`/`ofEpochMilli` instead `toMillisecondsSince1970`/`fromMillisecondsSince1970` can be a more idiomatic and shorter naming following java.time.Instant namings. If you also felt that way also don't think about my uses, better to have best namings (if you agree off course) before the release.

* https://www.tutorialspoint.com/javatime/javatime_instant_toepochmilli.htm
* https://www.tutorialspoint.com/javatime/javatime_instant_ofepochmilli.htm

java.time.Instant is a Java 8 offering so can be said is better than older things of Java to learn about conventions.