### PR TITLE
jvm: Upgrade Java language version to 11

### DIFF
--- a/.github/workflows/astronomy-engine-tests.yml
+++ b/.github/workflows/astronomy-engine-tests.yml
@@ -24,25 +24,21 @@ jobs:
     - name: Install documentation tools Linux
       if: startsWith(matrix.os, 'ubuntu')
       run: sudo apt install -y doxygen xsltproc
-    - name: Install documentation tools macOs
+    - name: Install documentation tools macOS
       if: startsWith(matrix.os, 'macOS')
       run: HOMEBREW_NO_AUTO_UPDATE=1 brew install doxygen
     - name: Init Node.js 14.x
       uses: actions/setup-node@v2
       with:
         node-version: 14.x
-    - name: set up JDK 1.8
+    - name: set up JDK 11
       uses: actions/setup-java@v1
       with:
-        java-version: 1.8
+        java-version: 11
     - uses: gradle/wrapper-validation-action@v1
 
-    - name: Test Astronomy Engine Linux
-      if: startsWith(matrix.os, 'ubuntu')
-      run: cd generate && rm -f output/vsop*.txt output/*.eph output/jupiter_moons.txt && ./run && ./verify_clean
-
-    - name: Test Astronomy Engine macOs
-      if: startsWith(matrix.os, 'macOS')
+    - name: Test Astronomy Engine Unix
+      if: startsWith(matrix.os, 'windows') == false
       run: cd generate && rm -f output/vsop*.txt output/*.eph output/jupiter_moons.txt && ./run && ./verify_clean
 
     - name: Test Astronomy Engine Windows

--- a/demo/java/build.gradle.kts
+++ b/demo/java/build.gradle.kts
@@ -6,6 +6,12 @@ plugins {
 group = "io.github.cosinekitty.astronomy.demo"
 version = "1.0.0"
 
+java {
+    toolchain {
+        languageVersion.set(JavaLanguageVersion.of(11))
+    }
+}
+
 repositories {
     mavenCentral()
     // maven("https://jitpack.io")

--- a/demo/java/src/main/java/io/github/cosinekitty/astronomy/demo/Main.java
+++ b/demo/java/src/main/java/io/github/cosinekitty/astronomy/demo/Main.java
@@ -59,7 +59,7 @@ public class Main {
         Optional<Demo> foundDemo = demoList.stream()
                 .filter(demo -> demo.name.equals(verb))
                 .findFirst();
-        if (!foundDemo.isPresent()) {
+        if (foundDemo.isEmpty()) {
             System.out.printf("ERROR: Unknown command '%s'.%n", verb);
             return 1;
         }

--- a/demo/kotlin/build.gradle.kts
+++ b/demo/kotlin/build.gradle.kts
@@ -22,7 +22,7 @@ tasks.test {
 }
 
 tasks.withType<KotlinCompile> {
-    kotlinOptions.jvmTarget = "1.8"
+    kotlinOptions.jvmTarget = "11"
     kotlinOptions {
         allWarningsAsErrors = true
     }

--- a/source/kotlin/build.gradle.kts
+++ b/source/kotlin/build.gradle.kts
@@ -26,7 +26,7 @@ tasks.test {
 }
 
 configure<JavaPluginExtension> {
-    sourceCompatibility = JavaVersion.VERSION_1_8
+    sourceCompatibility = JavaVersion.VERSION_11
 }
 
 val sourceJar by tasks.creating(Jar::class) {


### PR DESCRIPTION
Android Studio's embedded JDK is 11 and 11 can also be targeted in Android projects themselves so it feels like 11 is good enough to be the target.