### PR TITLE
Python: Few typehints for initial review

### DIFF
--- a/demo/python/astronomy.py
+++ b/demo/python/astronomy.py
@@ -125,7 +125,7 @@ _PLUTO_GM   = 0.2188699765425970e-11
 _MOON_GM = _EARTH_GM / _EARTH_MOON_MASS_RATIO
 
 
-def MassProduct(body):
+def MassProduct(body: "Body") -> float:
     """Returns the product of mass and universal gravitational constant of a Solar System body.
 
     For problems involving the gravitational interactions of Solar System bodies,
@@ -167,15 +167,15 @@ class _PrecessDir(enum.Enum):
     From2000 = 0
     Into2000 = 1
 
-def _LongitudeOffset(diff):
-    offset = diff
+def _LongitudeOffset(diff: float) -> float:
+    offset: float = diff
     while offset <= -180.0:
         offset += 360.0
     while offset > 180.0:
         offset -= 360.0
     return offset
 
-def _NormalizeLongitude(lon):
+def _NormalizeLongitude(lon: float) -> float:
     while lon < 0.0:
         lon += 360.0
     while lon >= 360.0:
@@ -200,34 +200,34 @@ class Vector:
     t : Time
         The date and time at which the coordinate is valid.
     """
-    def __init__(self, x, y, z, t):
+    def __init__(self, x: float, y: float, z: float, t: "Time") -> None:
         self.x = x
         self.y = y
         self.z = z
         self.t = t
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         return 'Vector({}, {}, {}, {})'.format(self.x, self.y, self.z, repr(self.t))
 
-    def Length(self):
+    def Length(self) -> float:
         """Returns the length of the vector in AU."""
         # It would be nice to use math.hypot() here,
         # but before Python 3.8, it only accepts 2 arguments.
         return math.sqrt(self.x**2 + self.y**2 + self.z**2)
 
-    def __add__(self, other):
+    def __add__(self, other: "Vector") -> "Vector":
         return Vector(self.x + other.x, self.y + other.y, self.z + other.z, self.t)
 
-    def __sub__(self, other):
+    def __sub__(self, other: "Vector") -> "Vector":
         return Vector(self.x - other.x, self.y - other.y, self.z - other.z, self.t)
 
-    def __neg__(self):
+    def __neg__(self) -> "Vector":
         return Vector(-self.x, -self.y, -self.z, self.t)
 
-    def __truediv__(self, scalar):
+    def __truediv__(self, scalar: float) -> "Vector":
         return Vector(self.x/scalar, self.y/scalar, self.z/scalar, self.t)
 
-    def format(self, coord_format):
+    def format(self, coord_format) -> str:
         """Returns a custom format string representation of the vector."""
         layout = '({:' + coord_format + '}, {:' + coord_format + '}, {:' + coord_format + '}, {})'
         return layout.format(self.x, self.y, self.z, str(self.t))
@@ -257,7 +257,7 @@ class StateVector:
     t : Time
         The date and time at which the position and velocity vectors are valid.
     """
-    def __init__(self, x, y, z, vx, vy, vz, t):
+    def __init__(self, x: float, y: float, z: float, vx: float, vy: float, vz: float, t: "Time") -> None:
         self.x = x
         self.y = y
         self.z = z
@@ -266,13 +266,13 @@ class StateVector:
         self.vz = vz
         self.t = t
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         return 'StateVector(x={}, y={}, z={}, vx={}, vy={}, vz={}, t={})'.format(
             self.x, self.y, self.z,
             self.vx, self.vy, self.vz,
             repr(self.t))
 
-    def __add__(self, other):
+    def __add__(self, other: "StateVector") -> "StateVector":
         return StateVector(
             self.x  + other.x,
             self.y  + other.y,
@@ -283,7 +283,7 @@ class StateVector:
             self.t
         )
 
-    def __sub__(self, other):
+    def __sub__(self, other: "StateVector") -> "StateVector":
         return StateVector(
             self.x  - other.x,
             self.y  - other.y,
@@ -294,11 +294,11 @@ class StateVector:
             self.t
         )
 
-    def Position(self):
+    def Position(self) -> Vector:
         """Extracts a position vector from this state vector."""
         return Vector(self.x, self.y, self.z, self.t)
 
-    def Velocity(self):
+    def Velocity(self) -> Vector:
         """Extracts a velocity vector from this state vector."""
         return Vector(self.vx, self.vy, self.vz, self.t)
 

--- a/generate/template/astronomy.py
+++ b/generate/template/astronomy.py
@@ -125,7 +125,7 @@ _PLUTO_GM   = 0.2188699765425970e-11
 _MOON_GM = _EARTH_GM / _EARTH_MOON_MASS_RATIO
 
 
-def MassProduct(body):
+def MassProduct(body: "Body") -> float:
     """Returns the product of mass and universal gravitational constant of a Solar System body.
 
     For problems involving the gravitational interactions of Solar System bodies,
@@ -167,15 +167,15 @@ class _PrecessDir(enum.Enum):
     From2000 = 0
     Into2000 = 1
 
-def _LongitudeOffset(diff):
-    offset = diff
+def _LongitudeOffset(diff: float) -> float:
+    offset: float = diff
     while offset <= -180.0:
         offset += 360.0
     while offset > 180.0:
         offset -= 360.0
     return offset
 
-def _NormalizeLongitude(lon):
+def _NormalizeLongitude(lon: float) -> float:
     while lon < 0.0:
         lon += 360.0
     while lon >= 360.0:
@@ -200,34 +200,34 @@ class Vector:
     t : Time
         The date and time at which the coordinate is valid.
     """
-    def __init__(self, x, y, z, t):
+    def __init__(self, x: float, y: float, z: float, t: "Time") -> None:
         self.x = x
         self.y = y
         self.z = z
         self.t = t
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         return 'Vector({}, {}, {}, {})'.format(self.x, self.y, self.z, repr(self.t))
 
-    def Length(self):
+    def Length(self) -> float:
         """Returns the length of the vector in AU."""
         # It would be nice to use math.hypot() here,
         # but before Python 3.8, it only accepts 2 arguments.
         return math.sqrt(self.x**2 + self.y**2 + self.z**2)
 
-    def __add__(self, other):
+    def __add__(self, other: "Vector") -> "Vector":
         return Vector(self.x + other.x, self.y + other.y, self.z + other.z, self.t)
 
-    def __sub__(self, other):
+    def __sub__(self, other: "Vector") -> "Vector":
         return Vector(self.x - other.x, self.y - other.y, self.z - other.z, self.t)
 
-    def __neg__(self):
+    def __neg__(self) -> "Vector":
         return Vector(-self.x, -self.y, -self.z, self.t)
 
-    def __truediv__(self, scalar):
+    def __truediv__(self, scalar: float) -> "Vector":
         return Vector(self.x/scalar, self.y/scalar, self.z/scalar, self.t)
 
-    def format(self, coord_format):
+    def format(self, coord_format) -> str:
         """Returns a custom format string representation of the vector."""
         layout = '({:' + coord_format + '}, {:' + coord_format + '}, {:' + coord_format + '}, {})'
         return layout.format(self.x, self.y, self.z, str(self.t))
@@ -257,7 +257,7 @@ class StateVector:
     t : Time
         The date and time at which the position and velocity vectors are valid.
     """
-    def __init__(self, x, y, z, vx, vy, vz, t):
+    def __init__(self, x: float, y: float, z: float, vx: float, vy: float, vz: float, t: "Time") -> None:
         self.x = x
         self.y = y
         self.z = z
@@ -266,13 +266,13 @@ class StateVector:
         self.vz = vz
         self.t = t
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         return 'StateVector(x={}, y={}, z={}, vx={}, vy={}, vz={}, t={})'.format(
             self.x, self.y, self.z,
             self.vx, self.vy, self.vz,
             repr(self.t))
 
-    def __add__(self, other):
+    def __add__(self, other: "StateVector") -> "StateVector":
         return StateVector(
             self.x  + other.x,
             self.y  + other.y,
@@ -283,7 +283,7 @@ class StateVector:
             self.t
         )
 
-    def __sub__(self, other):
+    def __sub__(self, other: "StateVector") -> "StateVector":
         return StateVector(
             self.x  - other.x,
             self.y  - other.y,
@@ -294,11 +294,11 @@ class StateVector:
             self.t
         )
 
-    def Position(self):
+    def Position(self) -> Vector:
         """Extracts a position vector from this state vector."""
         return Vector(self.x, self.y, self.z, self.t)
 
-    def Velocity(self):
+    def Velocity(self) -> Vector:
         """Extracts a velocity vector from this state vector."""
         return Vector(self.vx, self.vy, self.vz, self.t)
 

--- a/source/python/README.md
+++ b/source/python/README.md
@@ -896,12 +896,12 @@ The state vector also includes a time stamp.
 #### member functions
 
 <a name="StateVector.Position"></a>
-### StateVector.Position(self)
+### StateVector.Position(self) -&gt; astronomy.Vector
 
 Extracts a position vector from this state vector.
 
 <a name="StateVector.Velocity"></a>
-### StateVector.Velocity(self)
+### StateVector.Velocity(self) -&gt; astronomy.Vector
 
 Extracts a velocity vector from this state vector.
 
@@ -1055,12 +1055,12 @@ The vector also includes a time stamp.
 #### member functions
 
 <a name="Vector.Length"></a>
-### Vector.Length(self)
+### Vector.Length(self) -&gt; float
 
 Returns the length of the vector in AU.
 
 <a name="Vector.format"></a>
-### Vector.format(self, coord_format)
+### Vector.format(self, coord_format) -&gt; str
 
 Returns a custom format string representation of the vector.
 
@@ -2102,7 +2102,7 @@ and the apparent angular diameter of the Moon `diam_deg`.
 ---
 
 <a name="MassProduct"></a>
-### MassProduct(body)
+### MassProduct(body: 'Body') -&gt; float
 
 **Returns the product of mass and universal gravitational constant of a Solar System body.**
 

--- a/source/python/astronomy/astronomy.py
+++ b/source/python/astronomy/astronomy.py
@@ -125,7 +125,7 @@ _PLUTO_GM   = 0.2188699765425970e-11
 _MOON_GM = _EARTH_GM / _EARTH_MOON_MASS_RATIO
 
 
-def MassProduct(body):
+def MassProduct(body: "Body") -> float:
     """Returns the product of mass and universal gravitational constant of a Solar System body.
 
     For problems involving the gravitational interactions of Solar System bodies,
@@ -167,15 +167,15 @@ class _PrecessDir(enum.Enum):
     From2000 = 0
     Into2000 = 1
 
-def _LongitudeOffset(diff):
-    offset = diff
+def _LongitudeOffset(diff: float) -> float:
+    offset: float = diff
     while offset <= -180.0:
         offset += 360.0
     while offset > 180.0:
         offset -= 360.0
     return offset
 
-def _NormalizeLongitude(lon):
+def _NormalizeLongitude(lon: float) -> float:
     while lon < 0.0:
         lon += 360.0
     while lon >= 360.0:
@@ -200,34 +200,34 @@ class Vector:
     t : Time
         The date and time at which the coordinate is valid.
     """
-    def __init__(self, x, y, z, t):
+    def __init__(self, x: float, y: float, z: float, t: "Time") -> None:
         self.x = x
         self.y = y
         self.z = z
         self.t = t
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         return 'Vector({}, {}, {}, {})'.format(self.x, self.y, self.z, repr(self.t))
 
-    def Length(self):
+    def Length(self) -> float:
         """Returns the length of the vector in AU."""
         # It would be nice to use math.hypot() here,
         # but before Python 3.8, it only accepts 2 arguments.
         return math.sqrt(self.x**2 + self.y**2 + self.z**2)
 
-    def __add__(self, other):
+    def __add__(self, other: "Vector") -> "Vector":
         return Vector(self.x + other.x, self.y + other.y, self.z + other.z, self.t)
 
-    def __sub__(self, other):
+    def __sub__(self, other: "Vector") -> "Vector":
         return Vector(self.x - other.x, self.y - other.y, self.z - other.z, self.t)
 
-    def __neg__(self):
+    def __neg__(self) -> "Vector":
         return Vector(-self.x, -self.y, -self.z, self.t)
 
-    def __truediv__(self, scalar):
+    def __truediv__(self, scalar: float) -> "Vector":
         return Vector(self.x/scalar, self.y/scalar, self.z/scalar, self.t)
 
-    def format(self, coord_format):
+    def format(self, coord_format) -> str:
         """Returns a custom format string representation of the vector."""
         layout = '({:' + coord_format + '}, {:' + coord_format + '}, {:' + coord_format + '}, {})'
         return layout.format(self.x, self.y, self.z, str(self.t))
@@ -257,7 +257,7 @@ class StateVector:
     t : Time
         The date and time at which the position and velocity vectors are valid.
     """
-    def __init__(self, x, y, z, vx, vy, vz, t):
+    def __init__(self, x: float, y: float, z: float, vx: float, vy: float, vz: float, t: "Time") -> None:
         self.x = x
         self.y = y
         self.z = z
@@ -266,13 +266,13 @@ class StateVector:
         self.vz = vz
         self.t = t
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         return 'StateVector(x={}, y={}, z={}, vx={}, vy={}, vz={}, t={})'.format(
             self.x, self.y, self.z,
             self.vx, self.vy, self.vz,
             repr(self.t))
 
-    def __add__(self, other):
+    def __add__(self, other: "StateVector") -> "StateVector":
         return StateVector(
             self.x  + other.x,
             self.y  + other.y,
@@ -283,7 +283,7 @@ class StateVector:
             self.t
         )
 
-    def __sub__(self, other):
+    def __sub__(self, other: "StateVector") -> "StateVector":
         return StateVector(
             self.x  - other.x,
             self.y  - other.y,
@@ -294,11 +294,11 @@ class StateVector:
             self.t
         )
 
-    def Position(self):
+    def Position(self) -> Vector:
         """Extracts a position vector from this state vector."""
         return Vector(self.x, self.y, self.z, self.t)
 
-    def Velocity(self):
+    def Velocity(self) -> Vector:
         """Extracts a velocity vector from this state vector."""
         return Vector(self.vx, self.vy, self.vz, self.t)
 


### PR DESCRIPTION
Hi! I've written a few type hints for the first couple of classes/methods in reference to #276. I'd like to see if you're fine with them and I'll proceed then.

<img width="351" alt="image" src="https://user-images.githubusercontent.com/25360214/218395749-0db3c4b1-89b8-4346-8981-d75ef5bf1e81.png">


Comments:
- The reason there are some type hints written within quotations is because they're referencing a class that's defined before they are being referenced, which allows delayed annotations.

Issues: 
- I'm not exactly sure what's happening within the `__init__.py` file but it causes an issue with Mypy where it says the astronomy module doesn't exist. Any clarification on the init file would be great!
- I tried `from typing import Union` to allow a variable to have 2 different types. For example, the constructor of the `Time` class has a small segment where it checks if the`tt` variable is a string and does something else (lines 732-735). I ran into issues with `pydown.py`:
```
Generating Python documentation.
FATAL(pydown): Undocumented symbol: Union
ERROR(./makedoc): Error generating Markdown from Python source.
```
Am I supposed to declare a new import somewhere in the documentation?

Thanks!