### PR TITLE
Documenting Date usage in README.md

### DIFF
--- a/source/js/README.md
+++ b/source/js/README.md
@@ -118,6 +118,18 @@ and some [Node.js examples](../../demo/nodejs/).
 | [Seasons](#Seasons) | Finds the equinoxes and solstices for a given calendar year. |
 | [SunPosition](#SunPosition) | Calculates the Sun's apparent true ecliptic of date (ECT) coordinates as seen from the Earth. |
 
+### Date and time
+The Astronomy.js library performs its calculations in UTC through the use of the AstroTime class, which does not contain timezone information.
+AstroTime objects can be created in several ways, including through a Javascript Date object.
+
+A JavaScript Date object in UTC can be created using:
+- a Z-terminating string: <code>new Date('2024-07-01T09:00:00Z')</code>
+- a set of numbers, where the month is 0-based: <code>new Date(Date.UTC(2024, 6, 1, 9, 0, 0))</code>
+
+Both examples create a Date object set to July 1st 2024 at 9:00:00 UTC.
+
+Note that, when displaying Date objects as strings (with <code>toUTCString()</code> for instance), JavaScript incorrecly refers to UTC as 'GMT'.
+
 ### Coordinate transforms
 
 The following orientation systems are supported.


### PR DESCRIPTION
I propose to add some helpful information in the README file so users can easily create correct Date objects, as the JavaScript Date class can be confusing.
The Date class contains a timestamp (the number of milliseconds since Jan 1st 1970 at midnight), which is timezone-agnostic, but the methods to interact with this number do involve timezones. A little help may be useful.