### PR TITLE
fix missing initializer 'rot' warning

### DIFF
--- a/source/c/astronomy.c
+++ b/source/c/astronomy.c
@@ -11230,7 +11230,7 @@ static const constel_boundary_t ConstelBounds[] = {
 astro_constellation_t Astronomy_Constellation(double ra, double dec)
 {
     static astro_time_t epoch2000;
-    static astro_rotation_t rot = { ASTRO_NOT_INITIALIZED };
+    static astro_rotation_t rot = { ASTRO_NOT_INITIALIZED, {{0}} };
     astro_constellation_t constel;
     astro_spherical_t s2000;
     astro_equatorial_t b1875;


### PR DESCRIPTION
I came across this warning:

```
deps/astronomy/astronomy.c: In function ‘Astronomy_Constellation’:
deps/astronomy/astronomy.c:11233:5: warning: missing initializer for field ‘rot’ of ‘astro_rotation_t’ [-Wmissing-field-initializers]
11233 |     static astro_rotation_t rot = { ASTRO_NOT_INITIALIZED };
      |     ^~~~~~
In file included from deps/astronomy/astronomy.c:45:
deps/astronomy/astronomy.h:527:12: note: ‘rot’ declared here
  527 |     double rot[3][3];       /**< A normalized 3x3 rotation matrix. */
      |            ^~~
```

Changing line 11233 to:
```
static astro_rotation_t rot = { ASTRO_NOT_INITIALIZED, {{0}} };
```

Fixes the warning.